### PR TITLE
Ajout de fonctions de compatibilité, de correspondance image/xml et de rercherche dans les métadonnées

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -83,6 +83,7 @@ class Module extends AbstractModule
         $manifest = $event->getParam('manifest');
 
         // Manage last or recent version of module Iiif Server.
+        // TODO Why profile is /0/?
         $isVersion2 = !is_object($manifest);
         if ($isVersion2) {
             $manifest['service'][] = [
@@ -123,15 +124,12 @@ class Module extends AbstractModule
      */
     public function getConfigForm(PhpRenderer $renderer)
     {
-        $translate = $renderer->plugin('translate');
-
         $services = $this->getServiceLocator();
 
         $settings = $services->get('Omeka\Settings');
         $form = $services->get('FormElementManager')->get(ConfigForm::class);
-        $value = $settings->get("iiifsearch_minimum_query_length", 3);
         $params = [];
-        $params["iiifsearch_minimum_query_length"] = $value;
+        $params['iiifsearch_minimum_query_length'] = $settings->get('iiifsearch_minimum_query_length', 3);
         $form->init();
         $form->setData($params);
         return $renderer->formCollection($form);
@@ -147,7 +145,7 @@ class Module extends AbstractModule
         $services = $this->getServiceLocator();
         $settings = $services->get('Omeka\Settings');
         $params = $controller->getRequest()->getPost();
-        $settings->set("iiifsearch_minimum_query_length", intval($params["iiifsearch_minimum_query_length"]));
+        $settings->set('iiifsearch_minimum_query_length', intval($params['iiifsearch_minimum_query_length']));
     }
 
     /**

--- a/Module.php
+++ b/Module.php
@@ -130,6 +130,7 @@ class Module extends AbstractModule
         $form = $services->get('FormElementManager')->get(ConfigForm::class);
         $params = [];
         $params['iiifsearch_minimum_query_length'] = $settings->get('iiifsearch_minimum_query_length', 3);
+        $params['iiifsearch_xml_fix_mode'] = $settings->get('iiifsearch_xml_fix_mode', 'no');
         $form->init();
         $form->setData($params);
         return $renderer->formCollection($form);
@@ -146,6 +147,7 @@ class Module extends AbstractModule
         $settings = $services->get('Omeka\Settings');
         $params = $controller->getRequest()->getPost();
         $settings->set('iiifsearch_minimum_query_length', intval($params['iiifsearch_minimum_query_length']));
+        $settings->set('iiifsearch_xml_fix_mode', $params['iiifsearch_xml_fix_mode']);
     }
 
     /**

--- a/Module.php
+++ b/Module.php
@@ -130,6 +130,7 @@ class Module extends AbstractModule
         $form = $services->get('FormElementManager')->get(ConfigForm::class);
         $params = [];
         $params['iiifsearch_minimum_query_length'] = $settings->get('iiifsearch_minimum_query_length', 3);
+        $params['iiifsearch_xml_image_match'] = $settings->get('iiifsearch_xml_image_match', 'order');
         $params['iiifsearch_xml_fix_mode'] = $settings->get('iiifsearch_xml_fix_mode', 'no');
         $form->init();
         $form->setData($params);
@@ -147,6 +148,7 @@ class Module extends AbstractModule
         $settings = $services->get('Omeka\Settings');
         $params = $controller->getRequest()->getPost();
         $settings->set('iiifsearch_minimum_query_length', intval($params['iiifsearch_minimum_query_length']));
+        $settings->set('iiifsearch_xml_image_match', $params['iiifsearch_xml_image_match']);
         $settings->set('iiifsearch_xml_fix_mode', $params['iiifsearch_xml_fix_mode']);
     }
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ TODO
 
 - [ ] Auto complete.
 - [ ] Store data (word positions) as media data or item data or in a specific table or in Solr to speed up queries, in particular when alto are many.
+- [ ] Fix utf8 issues with dom.
 
 
 Troubleshooting

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Installation
 
 ```sh
 cd omeka-s/modules
-git clone git@github.com:bubdxm/Omeka-S-module-IiifSearch.git "IiifSearch"
+git clone git@github.com:symac/Omeka-S-module-IiifSearch.git "IiifSearch"
 ```
 
 - Enable it from Omeka admin → Modules → IiifSearch -> install

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -100,6 +100,7 @@ return [
         'config' => [
             'iiifsearch_minimum_query_length' => 3,
             'iiifsearch_disable_search_media_values' => false,
+            'iiifsearch_xml_image_match' => 'order',
             'iiifsearch_xml_fix_mode' => 'no',
         ],
     ],

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -98,6 +98,12 @@ return [
             ],
         ],
     ],
+    'iiifsearch' => [
+        'config' => [
+            'iiifsearch_minimum_query_length' => 3,
+            'iiifsearch_skip_search_media_values' => false,
+        ],
+    ],
     'iiifserver' => [
         'config' => [
             // This parameter may be overridden in your local config.

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -23,6 +23,11 @@ return [
             'iiifSearch' => Service\ViewHelper\IiifSearchFactory::class,
         ],
     ],
+    'form_elements' => [
+        'invokables' => [
+            Form\ConfigForm::class => Form\ConfigForm::class,
+        ],
+    ],
     'controllers' => [
         'invokables' => [
             'IiifSearch\Controller\Search' => Controller\SearchController::class,

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -16,10 +16,8 @@ return [
         ],
     ],
     'view_helpers' => [
-        'invokables' => [
-            'fixUtf8' => View\Helper\FixUtf8::class,
-        ],
         'factories' => [
+            'fixUtf8' => Service\ViewHelper\FixUtf8Factory::class,
             'iiifSearch' => Service\ViewHelper\IiifSearchFactory::class,
         ],
     ],
@@ -101,14 +99,8 @@ return [
     'iiifsearch' => [
         'config' => [
             'iiifsearch_minimum_query_length' => 3,
-            'iiifsearch_skip_search_media_values' => false,
+            'iiifsearch_disable_search_media_values' => false,
+            'iiifsearch_xml_fix_mode' => 'no',
         ],
     ],
-    'iiifserver' => [
-        'config' => [
-            // This parameter may be overridden in your local config.
-            // Disabled by default for performance.
-            'iiifserver_enable_utf8_fix' => false,
-        ],
-    ]
 ];

--- a/config/module.ini
+++ b/config/module.ini
@@ -1,11 +1,11 @@
 [info]
 name         = "Iiif Search"
-description  = "Search api for universal viewer module."
+description  = "Search api for IIIF compliant viewers (Universal Viewer, Mirador, etc.)"
 tags         = "iiif, search"
 license      = "GPL-3.0-or-later"
 author       = "bubdxm, improved by Daniel Berthereau"
 author_link  = "https://github.com/bubdxm"
 module_link  = "https://github.com/bubdxm/Omeka-S-module-IiifSearch"
 configurable = true
-version      = "3.4.3"
+version      = "3.4.4"
 omeka_version_constraint = "^3.1.0 || ^4.0.0"

--- a/data/scripts/upgrade.php
+++ b/data/scripts/upgrade.php
@@ -48,3 +48,16 @@ if (version_compare($oldVersion, '3.3.3', '<')) {
     $message->setEscapeHtml(false);
     $messenger->addWarning($message);
 }
+
+if (version_compare($oldVersion, '3.4.4', '<')) {
+    $settings->set('iiifsearch_disable_search_media_values', false);
+    $settings->set('iiifsearch_xml_fix_mode', 'no');
+    $message = new Message(
+        'A new option allows to include media metadata in search, not only full text.' // @translate
+    );
+    $messenger->addSuccess($message);
+    $message = new Message(
+        'A new option allows to fix bad xml and invalid utf-8 characters.' // @translate
+    );
+    $messenger->addSuccess($message);
+}

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -37,6 +37,32 @@ class ConfigForm extends Form
                 'attributes' => [
                     'id' => 'iiifsearch_disable_search_media_values',
                 ],
+            ])
+
+            // The option is the same in module IIIF Server.
+            ->add([
+                'name' => 'iiifsearch_xml_fix_mode',
+                'type' => Element\Radio::class,
+                'options' => [
+                    'label' => 'Fix bad xml and invalid utf-8 characters', // @translate
+                    'value_options' => [
+                        'no' => 'No', // @translate
+                        'dom' => 'Via DOM (quick)', // @translate
+                        'regex' => 'Via regex (slow)', // @translate
+                        'all' => 'All', // @translate
+                    ],
+                ],
+                'attributes' => [
+                    'id' => 'iiifsearch_xml_fix_mode',
+                    'value' => 'no',
+                ],
+            ]);
+
+        $inputFilter = $this->getInputFilter();
+        $inputFilter
+            ->add([
+                'name' => 'iiifsearch_xml_fix_mode',
+                'required' => false,
             ]);
     }
 }

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -4,50 +4,25 @@
 
 namespace IiifSearch\Form;
 
-
-use Laminas\EventManager\Event;
-use Laminas\EventManager\EventManagerAwareTrait;
 use Laminas\Form\Element;
-// use Laminas\Form\Element\Asset;
 use Laminas\Form\Form;
-use Laminas\I18n\Translator\TranslatorAwareInterface;
-use Laminas\I18n\Translator\TranslatorAwareTrait;
-use Laminas\Form\Fieldset;
 
-/**
- * ConfigForm
- */
-class ConfigForm extends Form implements TranslatorAwareInterface
+class ConfigForm extends Form
 {
-    use EventManagerAwareTrait;
-    use TranslatorAwareTrait;
-
     public function init(): void
     {
-        $addEvent = new Event('form.add_elements', $this);
-        $this->getEventManager()->triggerEvent($addEvent);
-
-        $inputFilter = $this->getInputFilter();
-
-        $this->add([
-            'name' => "iiifsearch_minimum_query_length",
-            'type' => Element\Number::class,
-            'options' => [
-                'label' => 'Minimum Query Length', // @translate
-            ],
-            'attributes' => [
-                "min" => 1,
-                "value" => 3
-            ],
-        ]);
-
-        $filterEvent = new Event('form.add_input_filters', $this, ['inputFilter' => $inputFilter]);
-        $this->getEventManager()->triggerEvent($filterEvent);
-    }
-
-    protected function translate($args)
-    {
-        $translator = $this->getTranslator();
-        return $translator->translate($args);
+        $this
+            ->add([
+                'name' => 'iiifsearch_minimum_query_length',
+                'type' => Element\Number::class,
+                'options' => [
+                    'label' => 'Minimum query length', // @translate
+                ],
+                'attributes' => [
+                    'id' => 'iiifsearch_minimum_query_length',
+                    'min' => 1,
+                    'value' => 3
+                ],
+            ]);
     }
 }

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -40,6 +40,24 @@ class ConfigForm extends Form
             ])
 
             // The option is the same in module IIIF Server.
+            // TODO Make option to match image and xml an option to set in a property of the item.
+            ->add([
+                'name' => 'iiifsearch_xml_image_match',
+                'type' => Element\Radio::class,
+                'options' => [
+                    'label' => 'Match images and xmls when they are multiple', // @translate
+                    'value_options' => [
+                        'order' => 'Media order (page_001.jpg, alto_001.xml, page_002.jpg, alto_002.xml, …)', // @translate
+                        'basename' => 'Media source base filename (page_001.jpg, page_002.jpg, page_002.xml, page_001.xml…)', // @translate
+                    ],
+                ],
+                'attributes' => [
+                    'id' => 'iiifsearch_xml_image_match',
+                    'value' => 'order',
+                ],
+            ])
+
+            // The option is the same in module IIIF Server.
             ->add([
                 'name' => 'iiifsearch_xml_fix_mode',
                 'type' => Element\Radio::class,

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -23,6 +23,20 @@ class ConfigForm extends Form
                     'min' => 1,
                     'value' => 3
                 ],
+            ])
+
+            // Motivation describing
+            // @see https://iiif.io/api/search/1.0/#query-parameters.
+            // Currently, motivations are not managed in common viewers.
+            ->add([
+                'name' => 'iiifsearch_disable_search_media_values',
+                'type' => Element\Checkbox::class,
+                'options' => [
+                    'label' => 'Disable search in media values', // @translate
+                ],
+                'attributes' => [
+                    'id' => 'iiifsearch_disable_search_media_values',
+                ],
             ]);
     }
 }

--- a/src/Iiif/AnnotationSearchResult.php
+++ b/src/Iiif/AnnotationSearchResult.php
@@ -147,12 +147,18 @@ class AnnotationSearchResult extends AbstractSimpleType
         $scaleX = $this->_result['image']['width'] / $this->_result['page']['width'];
         $scaleY = $this->_result['image']['height'] / $this->_result['page']['height'];
 
-        $x = $this->_result['zone']['left'] + mb_stripos($this->_result['zone']['text'], $this->_result['chars'])
+        if (strlen($this->_result['chars'])) {
+            $x = $this->_result['zone']['left'] + mb_stripos($this->_result['zone']['text'], $this->_result['chars'])
             / mb_strlen($this->_result['zone']['text']) * $this->_result['zone']['width'];
-        $y = $this->_result['zone']['top'];
-
-        $w = round($this->_result['zone']['width'] * ((mb_strlen($this->_result['chars']) + 1) / mb_strlen($this->_result['zone']['text']))) ;
-        $h = $this->_result['zone']['height'];
+            $y = $this->_result['zone']['top'];
+            $w = round($this->_result['zone']['width'] * ((mb_strlen($this->_result['chars']) + 1) / mb_strlen($this->_result['zone']['text']))) ;
+            $h = $this->_result['zone']['height'];
+        } else {
+            $x = $this->_result['zone']['left'];
+            $y = $this->_result['zone']['top'];
+            $w = $this->_result['zone']['width'];;
+            $h = $this->_result['zone']['height'];
+        }
 
         $this->_box['x'] = round($x * $scaleX);
         $this->_box['y'] = round($y * $scaleY);

--- a/src/Mvc/Controller/Plugin/SpecifyMediaType.php
+++ b/src/Mvc/Controller/Plugin/SpecifyMediaType.php
@@ -2,6 +2,8 @@
 
 namespace IiifSearch\Mvc\Controller\Plugin;
 
+use Doctrine\DBAL\Connection;
+use DOMDocument;
 use finfo;
 use Laminas\Log\Logger;
 use Laminas\Mvc\Controller\Plugin\AbstractPlugin;
@@ -13,10 +15,16 @@ use XMLReader;
  * @todo Make more precise media type for text/plain and application/json.
  *
  * @see \Omeka\File\TempFile
+ *
+ * @see \EasyAdmin\Mvc\Controller\Plugin\SpecifyMediaType
+ * @see \IiifSearch\Mvc\Controller\Plugin\SpecifyMediaType
+ * @see \XmlViewer\Mvc\Controller\Plugin\SpecifyMediaType
+ *
  * @see \BulkImport\Form\Reader\XmlReaderParamsForm
  * @see \EasyAdmin /data/media-types/media-type-identifiers
  * @see \ExtractText /data/media-types/media-type-identifiers
  * @see \IiifSearch /data/media-types/media-type-identifiers
+ * @see \IiifServer\Iiif\TraitIiifType
  * @see \XmlViewer /data/media-types/media-type-identifiers
  */
 class SpecifyMediaType extends AbstractPlugin
@@ -25,6 +33,16 @@ class SpecifyMediaType extends AbstractPlugin
      * @var \Laminas\Log\Logger
      */
     protected $logger;
+
+    /**
+     * @var \Doctrine\DBAL\Connection
+     */
+    protected $connection;
+
+    /**
+     * @var string
+     */
+    protected $basePath;
 
     /**
      * List of normalized media types extracted from files metadata.
@@ -38,16 +56,19 @@ class SpecifyMediaType extends AbstractPlugin
      */
     protected $filepath;
 
-    public function __construct(Logger $logger, array $mediaTypesIdentifiers)
-    {
+    public function __construct(
+        Logger $logger,
+        Connection $connection,
+        string $basePath,
+        array $mediaTypesIdentifiers
+    ) {
         $this->logger = $logger;
+        $this->connection = $connection;
+        $this->basePath = $basePath;
         $this->mediaTypesIdentifiers = $mediaTypesIdentifiers;
     }
 
-    /**
-     * @var ?string|bool $mediaType may be a bool due to a bug in core when the file is missing and FileTemp returns false as mediaType.
-     */
-    public function __invoke(string $filepath, $mediaType = null): ?string
+    public function __invoke(string $filepath, ?string $mediaType = null): ?string
     {
         $this->filepath = $filepath;
 
@@ -84,60 +105,78 @@ class SpecifyMediaType extends AbstractPlugin
      */
     protected function getMediaTypeXml(): ?string
     {
+        $type = null;
+
         libxml_clear_errors();
 
+        //  Try xmlreader first, quicker, but more strict.
         $reader = new XMLReader();
-        if (!$reader->open($this->filepath)) {
+        if ($reader->open($this->filepath)) {
+            // Don't output error in case of a badly formatted file since there is no logger.
+            while (@$reader->read()) {
+                if ($reader->nodeType === XMLReader::DOC_TYPE) {
+                    $type = $reader->name;
+                    break;
+                }
+
+                if ($reader->nodeType === XMLReader::PI
+                    && !in_array($reader->name, ['xml-stylesheet', 'oxygen'])
+                ) {
+                    $matches = [];
+                    if (preg_match('~href="(.+?)"~mi', $reader->value, $matches)) {
+                        $type = $matches[1];
+                        break;
+                    }
+                }
+
+                if ($reader->nodeType === XMLReader::ELEMENT) {
+                    // Fix exception.
+                    if ($reader->namespaceURI === 'urn:oasis:names:tc:opendocument:xmlns:office:1.0') {
+                        $type = $reader->getAttributeNs('mimetype', 'urn:oasis:names:tc:opendocument:xmlns:office:1.0');
+                    } else {
+                        $type = $reader->namespaceURI ?: $reader->getAttribute('xmlns') ?: $reader->name;
+                    }
+                    break;
+                }
+            }
+
+            $reader->close();
+
+            $error = libxml_get_last_error();
+            if ($error) {
+                // TODO Use PsrMessage.
+                $message = new \Omeka\Stdlib\Message(
+                    'Xml parsing error level %1$s, code %2$s, for file "%3$s" (media #%4$s), line %5$s, column %6$s: %7$s', // @translate
+                    $error->level, $error->code, $error->file, $this->getMediaIdFromFilePath(), $error->line, $error->column, $error->message
+                );
+                $this->logger->warn($message);
+            }
+
+            if ($type) {
+                return $this->mediaTypesIdentifiers[$type] ?? null;
+            }
+        }
+
+        // Try dom if xmlreader is too much strict.
+        $dom = $this->loadAndFixXml();
+        if (!$dom) {
             $message = new \Omeka\Stdlib\Message(
-                'The file "%1$s" is not parsable by xml reader.', // @translate
-                $this->filepath
+                'The file "%1$s" (media #2$s) is not parsable by xml reader neither dom.', // @translate
+                $this->filepath, $this->getMediaIdFromFilePath()
             );
             $this->logger->err($message);
             return null;
         }
 
-        $type = null;
+        $type = $dom->documentElement->namespaceURI
+            ?: ($dom->documentElement->getAttribute('xmlns')
+            ?: ($dom->documentElement->tagName
+            ?: ($dom->documentElement->localName
+            ?: $dom->documentElement->nodeName)));
 
-        // Don't output error in case of a badly formatted file since there is no logger.
-        while (@$reader->read()) {
-            if ($reader->nodeType === XMLReader::DOC_TYPE) {
-                $type = $reader->name;
-                break;
-            }
-
-            if ($reader->nodeType === XMLReader::PI
-                && !in_array($reader->name, ['xml-stylesheet', 'oxygen'])
-            ) {
-                $matches = [];
-                if (preg_match('~href="(.+?)"~mi', $reader->value, $matches)) {
-                    $type = $matches[1];
-                    break;
-                }
-            }
-
-            if ($reader->nodeType === XMLReader::ELEMENT) {
-                if ($reader->namespaceURI === 'urn:oasis:names:tc:opendocument:xmlns:office:1.0') {
-                    $type = $reader->getAttributeNs('mimetype', 'urn:oasis:names:tc:opendocument:xmlns:office:1.0');
-                } else {
-                    $type = $reader->namespaceURI ?: $reader->getAttribute('xmlns');
-                }
-                if (!$type) {
-                    $type = $reader->name;
-                }
-                break;
-            }
-        }
-
-        $reader->close();
-
-        $error = libxml_get_last_error();
-        if ($error) {
-            // TODO Use PsrMessage.
-            $message = new \Omeka\Stdlib\Message(
-                'Xml parsing error level %1$s, code %2$s, for file "%3$s", line %4$s, column %5$s: %6$s', // @translate
-                $error->level, $error->code, $error->file, $error->line, $error->column, $error->message
-            );
-            $this->logger->err($message);
+        // Fix exception.
+        if ($type === 'urn:oasis:names:tc:opendocument:xmlns:office:1.0') {
+            $type = $dom->documentElement->getAttributeNS('urn:oasis:names:tc:opendocument:xmlns:office:1.0', 'mimetype');
         }
 
         return $this->mediaTypesIdentifiers[$type] ?? null;
@@ -157,5 +196,130 @@ class SpecifyMediaType extends AbstractPlugin
         return substr($contents, 30, 8) === 'mimetype'
             ? substr($contents, 38, strpos($contents, 'PK', 38) - 38)
             : null;
+    }
+
+    /**
+     * Try to fix xml content before parsing.
+     */
+    protected function loadAndFixXml(): ?\DOMDocument
+    {
+        $xmlContent = file_get_contents($this->filepath);
+        if ($xmlContent) {
+            $xmlContent = $this->fixUtf8($xmlContent);
+            if ($xmlContent) {
+                return $this->fixXmlDom($xmlContent);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Some utf-8 files, generally edited under Windows, should be cleaned.
+     *
+     * Microsoft encodes many files with 16 bits (utf-16), so edition of a file
+     * encoded as utf-8 may be broken, or the file may be converted into utf-16
+     * without warning. This is particularly insidiuous for xml files, because
+     * its encoding scheme is declared in the first line and is not updated.
+     * The issue occurs with json files too, that must be utf-8 encoded.
+     *
+     * Microsoft is aware of this issue and that standards are not respected
+     * since some decades, but reject fixes, that is one of the multiple
+     * disloyal ways to force users to do all their workflow under Microsoft
+     * tools (server, os, office, etc.).
+     *
+     * The same issue occurs with Apple and Google or with any monopolistic
+     * publisher, so use only open standards and tools that really respect them,
+     * generallly free (libre).
+     *
+     * @see https://stackoverflow.com/questions/1401317/remove-non-utf8-characters-from-string#1401716
+     *
+     * Helper available in:
+     * @see \EasyAdmin\Mvc\Controller\Plugin\SpecifyMediaType::fixUtf8()
+     * @see \IiifServer\Mvc\Controller\Plugin\FixUtf8
+     * @see \IiifSearch\View\Helper\FixUtf8
+     */
+    protected function fixUtf8($string): string
+    {
+        $string = (string) $string;
+        if (!strlen($string)) {
+            return $string;
+        }
+
+        $regex = <<<'REGEX'
+/
+  (
+    (?: [\x00-\x7F]               # single-byte sequences   0xxxxxxx
+    |   [\xC0-\xDF][\x80-\xBF]    # double-byte sequences   110xxxxx 10xxxxxx
+    |   [\xE0-\xEF][\x80-\xBF]{2} # triple-byte sequences   1110xxxx 10xxxxxx * 2
+    |   [\xF0-\xF7][\x80-\xBF]{3} # quadruple-byte sequence 11110xxx 10xxxxxx * 3
+    ){1,100}                      # ...one or more times
+  )
+| ( [\x80-\xBF] )                 # invalid byte in range 10000000 - 10111111
+| ( [\xC0-\xFF] )                 # invalid byte in range 11000000 - 11111111
+/x
+REGEX;
+
+        $utf8replacer = function ($captures) {
+            if ($captures[1] !== '') {
+                // Valid byte sequence. Return unmodified.
+                return $captures[1];
+            } elseif ($captures[2] !== '') {
+                // Invalid byte of the form 10xxxxxx.
+                // Encode as 11000010 10xxxxxx.
+                return "\xC2" . $captures[2];
+            } else {
+                // Invalid byte of the form 11xxxxxx.
+                // Encode as 11000011 10xxxxxx.
+                return "\xC3" . chr(ord($captures[3]) - 64);
+            }
+        };
+
+        // Log invalid files.
+        $count = 0;
+        $result = preg_replace_callback($regex, $utf8replacer, $string, -1, $count);
+        if ($count && $string !== $result) {
+            $this->logger->warn(
+                'Warning: some files contain invalid unicode characters and cannot be processed directly.' // @translate
+            );
+        }
+
+        return $result;
+    }
+
+    protected function fixXmlDom(string $xmlContent): ?DOMDocument
+    {
+        libxml_use_internal_errors(true);
+        $dom = new DOMDocument('1.1', 'UTF-8');
+        $dom->strictErrorChecking = false;
+        $dom->validateOnParse = false;
+        $dom->recover = true;
+        $dom->loadXML($xmlContent);
+        libxml_clear_errors();
+        libxml_use_internal_errors(false);
+        return $dom;
+    }
+
+    protected function getMediaIdFromFilePath(): ?int
+    {
+        $pos = mb_strpos($this->filepath, $this->basePath);
+        if ($pos !== 0) {
+            return null;
+        }
+
+        $storage = mb_substr($this->filepath, mb_strlen($this->basePath) + 1);
+
+        // Remove the main dir ("original", "medium"…).
+        $pos = mb_strpos($storage, '/');
+        if ($pos !== false) {
+            $storage = mb_substr($storage, $pos + 1);
+        }
+
+        // Manage ArchiveRepertory.
+        $lengthExtension = mb_strlen(pathinfo($storage, PATHINFO_EXTENSION));
+        $storageId = $lengthExtension ? mb_substr($storage, 0, -$lengthExtension - 1) : $storage;
+
+        $sql = 'SELECT `id` FROM `media` WHERE `storage_id` = :storage_id LIMIT 1;';
+        $result = $this->connection->executeQuery($sql, ['storage_id' => $storageId])->fetchOne();
+        return $result ? (int) $result : null;
     }
 }

--- a/src/Mvc/Controller/Plugin/SpecifyMediaType.php
+++ b/src/Mvc/Controller/Plugin/SpecifyMediaType.php
@@ -44,7 +44,10 @@ class SpecifyMediaType extends AbstractPlugin
         $this->mediaTypesIdentifiers = $mediaTypesIdentifiers;
     }
 
-    public function __invoke(string $filepath, ?string $mediaType = null): ?string
+    /**
+     * @var ?string|bool $mediaType may be a bool due to a bug in core when the file is missing and FileTemp returns false as mediaType.
+     */
+    public function __invoke(string $filepath, $mediaType = null): ?string
     {
         $this->filepath = $filepath;
 

--- a/src/Service/ControllerPlugin/SpecifyMediaTypeFactory.php
+++ b/src/Service/ControllerPlugin/SpecifyMediaTypeFactory.php
@@ -10,9 +10,12 @@ class SpecifyMediaTypeFactory implements FactoryInterface
 {
     public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
     {
+        $config = $services->get('Config');
         $mediaTypesIdentifiers = require_once dirname(__DIR__, 3) . '/data/media-types/media-type-identifiers.php';
         return new SpecifyMediaType(
             $services->get('Omeka\Logger'),
+            $services->get('Omeka\Connection'),
+            $config['file_store']['local']['base_path'] ?: (OMEKA_PATH . '/files'),
             $mediaTypesIdentifiers
         );
     }

--- a/src/Service/ViewHelper/FixUtf8Factory.php
+++ b/src/Service/ViewHelper/FixUtf8Factory.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace IiifSearch\Service\ViewHelper;
+
+use IiifSearch\View\Helper\FixUtf8;
+use Interop\Container\ContainerInterface;
+
+class FixUtf8Factory
+{
+    public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
+    {
+        return new FixUtf8(
+            $services->get('Omeka\Logger')
+        );
+    }
+}

--- a/src/Service/ViewHelper/IiifSearchFactory.php
+++ b/src/Service/ViewHelper/IiifSearchFactory.php
@@ -22,6 +22,7 @@ class IiifSearchFactory
             $plugins->has('imageSize') ? $plugins->get('imageSize') : null,
             $basePath,
             !$settings->get('iiifsearch_disable_search_media_values'),
+            $settings->get('iiifsearch_xml_image_match', 'order'),
             $settings->get('iiifsearch_xml_fix_mode', 'no')
         );
     }

--- a/src/Service/ViewHelper/IiifSearchFactory.php
+++ b/src/Service/ViewHelper/IiifSearchFactory.php
@@ -12,13 +12,17 @@ class IiifSearchFactory
         $config = $services->get('Config');
         $basePath = $config['file_store']['local']['base_path'] ?: (OMEKA_PATH . '/files');
         $plugins = $services->get('ControllerPluginManager');
+        $helpers = $services->get('ViewHelperManager');
+
         return new IiifSearch(
             $services->get('Omeka\Logger'),
+            $services->get('Omeka\ApiManager'),
             empty($config['iiifserver']['config']['iiifserver_enable_utf8_fix'])
                 ? null
-                : $services->get('ViewHelperManager')->get('fixUtf8'),
+                : $helpers->get('fixUtf8'),
             $plugins->has('imageSize') ? $plugins->get('imageSize') : null,
-            $basePath
+            $basePath,
+            !$services->get('Omeka\Settings')->get('iiifsearch_disable_search_media_values')
         );
     }
 }

--- a/src/Service/ViewHelper/IiifSearchFactory.php
+++ b/src/Service/ViewHelper/IiifSearchFactory.php
@@ -13,16 +13,16 @@ class IiifSearchFactory
         $basePath = $config['file_store']['local']['base_path'] ?: (OMEKA_PATH . '/files');
         $plugins = $services->get('ControllerPluginManager');
         $helpers = $services->get('ViewHelperManager');
+        $settings = $services->get('Omeka\Settings');
 
         return new IiifSearch(
             $services->get('Omeka\Logger'),
             $services->get('Omeka\ApiManager'),
-            empty($config['iiifserver']['config']['iiifserver_enable_utf8_fix'])
-                ? null
-                : $helpers->get('fixUtf8'),
+            $helpers->get('fixUtf8'),
             $plugins->has('imageSize') ? $plugins->get('imageSize') : null,
             $basePath,
-            !$services->get('Omeka\Settings')->get('iiifsearch_disable_search_media_values')
+            !$settings->get('iiifsearch_disable_search_media_values'),
+            $settings->get('iiifsearch_xml_fix_mode', 'no')
         );
     }
 }

--- a/src/View/Helper/FixUtf8.php
+++ b/src/View/Helper/FixUtf8.php
@@ -2,10 +2,22 @@
 
 namespace IiifSearch\View\Helper;
 
+use Laminas\Log\Logger;
 use Laminas\View\Helper\AbstractHelper;
 
 class FixUtf8 extends AbstractHelper
 {
+    /**
+     * @var \Laminas\Log\Logger
+     */
+    protected $logger;
+
+    public function __construct(
+        Logger $logger
+    ) {
+        $this->logger = $logger;
+    }
+
     /**
      * Some utf-8 files, generally edited under Windows, should be cleaned.
      *
@@ -25,11 +37,16 @@ class FixUtf8 extends AbstractHelper
      * generallly free (libre).
      *
      * @see https://stackoverflow.com/questions/1401317/remove-non-utf8-characters-from-string#1401716
+     *
+     * Helper available in:
+     * @see \EasyAdmin\Mvc\Controller\Plugin\SpecifyMediaType::fixUtf8()
+     * @see \IiifServer\Mvc\Controller\Plugin\FixUtf8
+     * @see \IiifSearch\View\Helper\FixUtf8
      */
     public function __invoke($string): string
     {
         $string = (string) $string;
-        if (!$string) {
+        if (!strlen($string)) {
             return $string;
         }
 
@@ -66,7 +83,7 @@ REGEX;
         $count = 0;
         $result = preg_replace_callback($regex, $utf8replacer, $string, -1, $count);
         if ($count && $string !== $result) {
-            $this->getView()->get('logger')->warn(sprintf(
+            $this->logger->warn(sprintf(
                 'Warning: some files contain invalid unicode characters and cannot be searched quickly.' // @translate
             ));
         }


### PR DESCRIPTION
Bonjour Sylvain,

J'ai mis à jour le module pour mieux gérer l'alto et des fichiers xml pas conforme, mais qu'il n'est pas possible de modifier.

De même pour l'ordre des xml et la correspondance avec les images.

On peut aussi rechercher dans les métadonnées des médias et tomber sur les bonnes pages.

Cordialement,
